### PR TITLE
Ensure that README.md is included in tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,4 +10,6 @@ testspooky_c_LDADD = -lrt libspooky-c.la
 
 include_HEADERS = spooky-c.h
 
+EXTRA_DIST = README.md
+
 TESTS = testspooky-c

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![spooky-c] (http://halobates.de/spooky-c.png)
 
-This is a C version of Bob Jenkin's spooky hash. The only advantage over
+This is a C version of Bob Jenkins' spooky hash. The only advantage over
 Bob's original version is that it is in C, not C++ and comes with
 some test and benchmark code.
 


### PR DESCRIPTION
One more minor patch. This is needed to ensure that  the README.md file is included in "make dist" tarballs.

Also, would it be ok to tag this at v1.0.0 for a release? I've done so in my repo, but I'm not sure that tags come across in pull requests.